### PR TITLE
ignore query params when checking the filename

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,13 +52,14 @@ export function createSvgPlugin(
   return {
     name: "vite-plugin-vue2-svg",
     async transform(_source: string, id: string) {
-      const isMatch = id.match(svgRegex);
+      const fname = id.replace(/\?.*$/, "");
+      const isMatch = svgRegex.test(fname);
       if (isMatch) {
-        const code: string = readFileSync(id, { encoding: "utf-8" });
-        const svg = await optimizeSvg(svgo, code, id);
+        const code: string = readFileSync(fname, { encoding: "utf-8" });
+        const svg = await optimizeSvg(svgo, code, fname);
         if (!svg)
           throw new Error(`[vite-plugin-vue2-svg] fail to compile ${id}`);
-        const result = compileSvg(svg, id);
+        const result = compileSvg(svg, fname);
 
         return result;
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "removeComments": true,
     "sourceMap": true,
     "downlevelIteration": true,
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "outDir": "./lib",
     "declaration": true
   },


### PR DESCRIPTION
When used in a Nuxt project with [nuxt-vite](https://vite.nuxtjs.org/) the dependency name might come with a query string since that's used by the default webpack based loader (i.e. `assets/icon.svg?inline`). So in order to be compatible with both build systems we'll need this plugin to ignore any query params included in the filename.

Also as part of the changes I had to do include the _dom_ api in the tsconfig file for the build to succeed.