### PR TITLE
Support sourcemaps in the build

### DIFF
--- a/examples/vite-svg-example/vite.config.js
+++ b/examples/vite-svg-example/vite.config.js
@@ -1,5 +1,8 @@
 const { createSvgPlugin } = require("vite-plugin-vue2-svg");
 const { createVuePlugin } = require("vite-plugin-vue2");
 module.exports = {
+  build: {
+    sourcemap: true,
+  },
   plugins: [createVuePlugin(), createSvgPlugin({})],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ interface CompileResult {
 }
 
 function compileSvg(svg: any, id: string): CompileResult | null {
-  const component = parse({
+  const { template, script } = parse({
     source: `
       <template>
         ${svg}
@@ -26,11 +26,11 @@ function compileSvg(svg: any, id: string): CompileResult | null {
     filename: `${basename(id)}.vue`,
   });
 
-  if (!component || !component.template) return null;
+  if (!template) return null;
 
   const result = compileTemplate({
     compiler: compiler as any,
-    source: component.template.content,
+    source: template.content,
     filename: `${basename(id)}.vue`,
   });
 
@@ -41,7 +41,7 @@ function compileSvg(svg: any, id: string): CompileResult | null {
         render: render,
       }
     `,
-    map: component.script?.map,
+    map: script?.map,
   };
 }
 


### PR DESCRIPTION
## Changes
- Add `<script>` to transformed SVG component so a sourcemap gets generated

```
Sourcemap is likely to be incorrect: a plugin (vite-plugin-vue2-svg) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

When sourcemaps are enabled in the `vite.config.(js|ts)`, the sourcemap gets generated with the vite build.